### PR TITLE
fix pause bug

### DIFF
--- a/source/electron-ui/js/connector.js
+++ b/source/electron-ui/js/connector.js
@@ -151,8 +151,10 @@ async function addNextFileToPreset() {
         await sleep(500);
     } while (lastFileAddedIdx+1 < filesToAdd.length);
 
-    await sleep(1500);
-    window.location.href = 'create.html';
+    if (!pause) {
+        await sleep(1500);
+        window.location.href = 'create.html';
+    }
 }
 
 var disableDeleteButton = true;


### PR DESCRIPTION
The window now should only reload the create page if it has exited the moving cycle when not pausing.