### PR TITLE
preset importing -> main

### DIFF
--- a/source/dataHandlers/presetManager.py
+++ b/source/dataHandlers/presetManager.py
@@ -472,22 +472,6 @@ class PresetManager:
 
         print("The preset was successfully imported.")
         return True
-                
-        @staticmethod
-        def get_next_available_id():
-            '''
-            Returns the next available id
-            '''
-            highest_id = -1
-
-            presets = PresetManager.get_all_entries()
-            for preset in presets:
-                if int(preset.id) > int(highest_id):
-                    highest_id = preset.id
-            
-            highest_id = int(highest_id) + 1
-
-            return str(highest_id)
 
     @staticmethod
     def export_preset(source_file:str, destination_file:str, preset_name:str):

--- a/source/dataHandlers/presetManager.py
+++ b/source/dataHandlers/presetManager.py
@@ -13,7 +13,7 @@ class PresetManager:
 
     global PRESETS_DIRECTORY 
     global REPOSITORY_DIRECTORY
-    global PRESET_LIST_FILE_NAME
+    global PRESET_LIST_FILE_NAME 
     global HOME_DIRECTORY
     global DESKTOP_PATH
     global DEVELOPER_MODE
@@ -462,6 +462,9 @@ class PresetManager:
         if found_preset is None:
             print("The specified preset was not found in the source file.")
             return False
+
+        # Swap the ID to an ID that is not already in use
+        found_preset['id'] = PresetManager.get_next_available_id()
 
         # Copy the preset object to the destination file
         destination_data['presets'].append(found_preset)

--- a/source/electron-ui/import-export.html
+++ b/source/electron-ui/import-export.html
@@ -85,15 +85,19 @@
                         <h6 class="mb-4">Import a Preset</h6>
                         <form>
                             <div class="mb-3">
-                                <label for="input_preset_name" class="form-label">Filepath</label>
+                                <label for="input_preset_name" class="form-label">Source File Path</label>
+                                <input type="text" class="form-control" id="input_source_preset">
+                            </div>
+                            <div class="mb-3">
+                                <label for="input_preset_name" class="form-label">Preset Name</label>
                                 <input type="text" class="form-control" id="input_preset_name">
                             </div>
                         </form>
-                        <button type="submit" class="btn btn-primary" onclick="importPreset()">Import</button>
+                        <button type="submit" class="btn btn-primary" onclick="sendImportRequest()">Import</button>
                     </div>
                 </div>
             </div>
-            
+
         </div>
         <!-- Form End -->
             
@@ -130,6 +134,9 @@
 
     <!-- Javascript -->
     <script src="js/main.js"></script>
+
+    <!-- Connector to the Python Backend -->
+    <script src="./js/connector.js"></script>
 </body>
 
 </html>

--- a/source/electron-ui/import-export.html
+++ b/source/electron-ui/import-export.html
@@ -77,49 +77,26 @@
             </nav>
             <!-- Navbar End -->
 
-            <!-- Sale & Revenue Start -->
-            <div class="container-fluid pt-4 px-4">
-                <div class="row g-4">
-                    <div class="col-sm-6 col-xl-3">
-                        <div class="bg-secondary rounded d-flex align-items-center justify-content-between p-4">
-                            <i class="fa fa-chart-bar fa-3x text-primary"></i>
-                            <div class="ms-3">
-                                <p class="mb-2">Presets</p>
-                                <h6 class="mb-0">23</h6>
+            <!-- Form Start -->
+           <div class="container-fluid pt-4 px-4">
+            <div class="row g-4">
+                <div class="col-sm-12 col-xl-6">
+                    <div class="bg-secondary rounded h-100 p-4">
+                        <h6 class="mb-4">Import a Preset</h6>
+                        <form>
+                            <div class="mb-3">
+                                <label for="input_preset_name" class="form-label">Filepath</label>
+                                <input type="text" class="form-control" id="input_preset_name">
                             </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-xl-3">
-                        <div class="bg-secondary rounded d-flex align-items-center justify-content-between p-4">
-                            <i class="fa fa-file fa-3x text-primary"></i>
-                            <div class="ms-3">
-                                <p class="mb-2">Files</p>
-                                <h6 class="mb-0">1.259</h6>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-xl-3">
-                        <div class="bg-secondary rounded d-flex align-items-center justify-content-between p-4">
-                            <i class="fa fa-plus fa-3x text-primary"></i>
-                            <div class="ms-3">
-                                <p class="mb-2">Created</p>
-                                <h6 class="mb-0">15</h6>
-                            </div>
-                        </div>
-                    </div>
-                    <div class="col-sm-6 col-xl-3">
-                        <div class="bg-secondary rounded d-flex align-items-center justify-content-between p-4">
-                            <i class="fa fa-download fa-3x text-primary"></i>
-                            <div class="ms-3">
-                                <p class="mb-2">Downloaded</p>
-                                <h6 class="mb-0">8</h6>
-                            </div>
-                        </div>
+                        </form>
+                        <button type="submit" class="btn btn-primary" onclick="importPreset()">Import</button>
                     </div>
                 </div>
             </div>
-            <!-- Sale & Revenue End -->
-
+            
+        </div>
+        <!-- Form End -->
+            
             <!-- Footer Start -->
             <div class="pt-4 px-4" id="footer">
                 <div class="bg-secondary rounded-top p-4">

--- a/source/electron-ui/js/connector.js
+++ b/source/electron-ui/js/connector.js
@@ -72,6 +72,22 @@ function savePreset(presetId) {
         success: (response) => {console.log(response)}
     });
 }
+
+function importPreset(sourceParam, nameParam) {
+    $.ajax({
+        type: "POST",
+        url: "http://localhost:5000/import",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        data: JSON.stringify({
+            source: sourceParam,
+            name: nameParam
+        }),
+        success: (response) => {console.log("[connector.js] importPreset > response: " + response)}
+    });
+}
+
 // +++ Callback functions for the AJAX Requests +++
 
 function fillListWithPresets(response) {
@@ -294,6 +310,17 @@ function sortTable(columnIndex) {
             switching = true;
         }
     }
+}
+
+function sendImportRequest() {
+    // to be implemented
+
+    // Gather data from inputfields
+    preset_source_path = $('#input_source_preset').val();
+    preset_name = $('#input_preset_name').val();
+
+    // Call function
+    importPreset(preset_source_path, preset_name);
 }
 
 function sleep(ms) {

--- a/source/python-api/dhapi.py
+++ b/source/python-api/dhapi.py
@@ -18,6 +18,7 @@ sys.path.append(pathToDataHandlers)
 
 # 4) Import the dataHandlers
 from dataHandlers.presetManager import PresetManager as pmgr
+from dataHandlers.presetManager import PRESET_LIST_FILE_NAME
 
 app = Flask(__name__)
 api = Api(app)
@@ -76,11 +77,21 @@ class PresetSaveEndpoint(Resource):
                 return "Preset '" + actPres.name + "' loaded."
             
         return "ERROR: No preset with id '" + str(presetId) + "'."
+    
+class PresetImportEndpoint(Resource):
+    def post(self):
+        data = request.get_json()
+        # TODO: Handle case when no parameter is getting passed
+        # TODO: Require non-empty stirng at Fronend, Backend and here (as the TODO above says)
+        # response = pmgr.import_preset(data['source'], data['destination'], data['name'])
+        response = pmgr.import_preset(data['source'], PRESET_LIST_FILE_NAME, data['name'])
+        return response
 
 api.add_resource(PresetEndpoints, '/id/<int:presetId>')
 api.add_resource(PresetListEndpoints, '/')
 api.add_resource(PresetLoadEndpoint, '/load/<int:presetId>')
 api.add_resource(PresetSaveEndpoint, '/save/<int:presetId>')
+api.add_resource(PresetImportEndpoint, '/import')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/source/testing/presetmanagertesting.py
+++ b/source/testing/presetmanagertesting.py
@@ -19,13 +19,21 @@ sys.path.append(pathToDataHandlers)
 # 4) Import the dataHandlers
 from dataHandlers.presetManager import PresetManager as pmgr
 
-#from source import presetManager as pmgr
+# from source import presetManager as pmgr
 
-# print("-> Started Tests...")
+print(" > Started Tests...")
+
+print("[Test 1] > Importing a preset")
+source_file = "C:\\Users\\bence\\Desktop\\presetToImport.json"
+destination_file = "C:\\Users\\bence\\AppData\\Local\\DLO\\Presets\\PresetList.json"
+preset_name = "test0012409"
+print("[Test 1] > ", source_file, destination_file, preset_name)
+pmgr.import_preset(source_file, destination_file, preset_name)
+print(" > importing done...")
 
 # Test 1:
 
-pmgr.load_preset("imp3")
+# pmgr.load_preset("imp3")
 
 # print("[Test 1] > Creating a preset with name")
 # presName = input("[Test 1] Name of new preset: ")
@@ -96,5 +104,3 @@ pmgr.load_preset("imp3")
 #    print("> [" + str(i) +"]: " + filepath)
 #    i = i + 1
 #    pmgr.copy_file_to_repository(filepath)
-
-confirm = input("Press a button to continue...")


### PR DESCRIPTION
Presets now can be imported via a Path and the name of the preset in the given file.

App:

![image](https://github.com/bence-d/Desktop-Layout-Organizer/assets/64145054/fb17cb78-7ece-49ae-9eb2-cab5eb4f497e)

API:

![image](https://github.com/bence-d/Desktop-Layout-Organizer/assets/64145054/f0a6753b-1304-4c03-8029-0bd16b901984)

File Structure:

![image](https://github.com/bence-d/Desktop-Layout-Organizer/assets/64145054/e747390f-5d44-4073-9e50-2ca56e7ecdd6)

- File Structure: An object, that has an array of presets
  - That's why you **need to specify the name of the presets** (to pick one from the array)
  - As you can see, the **ID** is random, the backend ignores the ID in the file and assigns the internally generated instead

