### PR TITLE
Private/bence d/exporting presets

### DIFF
--- a/source/dataHandlers/presetManager.py
+++ b/source/dataHandlers/presetManager.py
@@ -484,8 +484,14 @@ class PresetManager:
         :return: True if the preset was exported successfully, False otherwise\n
         '''
 
-        #import_preset and export_preset are the same function, the only difference is the order of the parameters
-        return PresetManager.import_preset(DESKTOP_PATH,PRESET_LIST_FILE_NAME,preset_name)
+        destination_file = os.path.join(DESKTOP_PATH, (preset_name + ".json"))
+
+        # Open the file in write mode and create it if it doesn't exist
+        with open(os.path.join(DESKTOP_PATH, (preset_name + ".json")), "w") as file:
+            file.write('{"presets": []}')
+
+        # import_preset and export_preset are the same function, the only difference is the order of the parameters
+        return PresetManager.import_preset(PRESET_LIST_FILE_NAME, destination_file, preset_name)
 
     @staticmethod
     def get_next_available_id():

--- a/source/dataHandlers/presetManager.py
+++ b/source/dataHandlers/presetManager.py
@@ -477,17 +477,15 @@ class PresetManager:
         return True
 
     @staticmethod
-    def export_preset(source_file:str, destination_file:str, preset_name:str):
+    def export_preset(preset_name:str):
         '''
-        Exports a preset from a source file to a destination file\n
-        :param source_file: The source file to export the preset from\n
-        :param destination_file: The destination file to export the preset to\n
-        :param preset_name: The name of the preset to export\n
+        Exports a preset from the presetlist to the desktop\n
+        :param preset_id: The ID of the preset that's to be exported\n
         :return: True if the preset was exported successfully, False otherwise\n
         '''
 
         #import_preset and export_preset are the same function, the only difference is the order of the parameters
-        PresetManager.import_preset(destination_file,source_file,preset_name)
+        return PresetManager.import_preset(DESKTOP_PATH,PRESET_LIST_FILE_NAME,preset_name)
 
     @staticmethod
     def get_next_available_id():

--- a/source/electron-ui/import-export.html
+++ b/source/electron-ui/import-export.html
@@ -77,7 +77,7 @@
             </nav>
             <!-- Navbar End -->
 
-            <!-- Form Start -->
+            <!-- Import Form Start -->
            <div class="container-fluid pt-4 px-4">
             <div class="row g-4">
                 <div class="col-sm-12 col-xl-6">
@@ -94,6 +94,22 @@
                             </div>
                         </form>
                         <button type="submit" class="btn btn-primary" onclick="sendImportRequest()">Import</button>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Export Form Start -->
+            <div class="row g-4 my-1">
+                <div class="col-sm-12 col-xl-6">
+                    <div class="bg-secondary rounded h-100 p-4">
+                        <h6 class="mb-4">Export a Preset</h6>
+                        <form>
+                            <div class="mb-3">
+                                <label for="export_preset_name" class="form-label">Preset Name</label>
+                                <input type="text" class="form-control" id="export_preset_name">
+                            </div>
+                        </form>
+                        <button type="submit" class="btn btn-primary" onclick="sendExportRequest()">Export</button>
                     </div>
                 </div>
             </div>

--- a/source/electron-ui/js/connector.js
+++ b/source/electron-ui/js/connector.js
@@ -88,6 +88,20 @@ function importPreset(sourceParam, nameParam) {
     });
 }
 
+function exportPreset(nameParam) {
+    $.ajax({
+        type: "POST",
+        url: "http://localhost:5000/export",
+        headers: {
+            "Content-Type": "application/json"
+        },
+        data: JSON.stringify({
+            name: nameParam
+        }),
+        success: (response) => {console.log("[connector.js] exportPreset > response: " + response)}
+    });
+}
+
 // +++ Callback functions for the AJAX Requests +++
 
 function fillListWithPresets(response) {
@@ -313,8 +327,6 @@ function sortTable(columnIndex) {
 }
 
 function sendImportRequest() {
-    // to be implemented
-
     // Gather data from inputfields
     preset_source_path = $('#input_source_preset').val();
     preset_name = $('#input_preset_name').val();
@@ -322,6 +334,15 @@ function sendImportRequest() {
     // Call function
     importPreset(preset_source_path, preset_name);
 }
+
+function sendExportRequest() {
+    // Gather data from inputfields
+    preset_name = $('#export_preset_name').val();
+
+    // Call function
+    exportPreset(preset_name);
+}
+
 
 function sleep(ms) {
     return new Promise(resolve => setTimeout(resolve, ms));

--- a/source/python-api/dhapi.py
+++ b/source/python-api/dhapi.py
@@ -86,12 +86,21 @@ class PresetImportEndpoint(Resource):
         # response = pmgr.import_preset(data['source'], data['destination'], data['name'])
         response = pmgr.import_preset(data['source'], PRESET_LIST_FILE_NAME, data['name'])
         return response
+    
+class PresetExportEndpoint(Resource):
+    def post(self):
+        data = request.get_json()
+        # TODO: Handle case when no parameter is getting passed
+        # TODO: Require non-empty stirng at Fronend, Backend and here (as the TODO above says)
+        response = pmgr.export_preset(data['name'])
+        return response
 
 api.add_resource(PresetEndpoints, '/id/<int:presetId>')
 api.add_resource(PresetListEndpoints, '/')
 api.add_resource(PresetLoadEndpoint, '/load/<int:presetId>')
 api.add_resource(PresetSaveEndpoint, '/save/<int:presetId>')
 api.add_resource(PresetImportEndpoint, '/import')
+api.add_resource(PresetExportEndpoint, '/export')
 
 if __name__ == '__main__':
     app.run(debug=True)

--- a/source/testing/presetmanagertesting.py
+++ b/source/testing/presetmanagertesting.py
@@ -23,13 +23,18 @@ from dataHandlers.presetManager import PresetManager as pmgr
 
 print(" > Started Tests...")
 
-print("[Test 1] > Importing a preset")
-source_file = "C:\\Users\\bence\\Desktop\\presetToImport.json"
-destination_file = "C:\\Users\\bence\\AppData\\Local\\DLO\\Presets\\PresetList.json"
-preset_name = "test0012409"
-print("[Test 1] > ", source_file, destination_file, preset_name)
-pmgr.import_preset(source_file, destination_file, preset_name)
-print(" > importing done...")
+# print("[Test 1] > Importing a preset")
+# source_file = "C:\\Users\\bence\\Desktop\\presetToImport.json"
+# destination_file = "C:\\Users\\bence\\AppData\\Local\\DLO\\Presets\\PresetList.json"
+# preset_name = "test0012409"
+# print("[Test 1] > ", source_file, destination_file, preset_name)
+# pmgr.import_preset(source_file, destination_file, preset_name)
+# print(" > importing done...")
+
+print("[Test 2] > Exporting a preset")
+preset_name = "gaming2"
+pmgr.export_preset(preset_name)
+print(" > exporting done...")
 
 # Test 1:
 


### PR DESCRIPTION
Presets now can be exported via a name on the desktop.

App: 

![image](https://github.com/bence-d/Desktop-Layout-Organizer/assets/64145054/368858d1-d9af-4193-a84f-130ef9720e39)

API:
![image](https://github.com/bence-d/Desktop-Layout-Organizer/assets/64145054/2a83de0b-c8cb-4098-9b69-76c8e993e6c7)

File Structure:
![image](https://github.com/bence-d/Desktop-Layout-Organizer/assets/64145054/607eed3c-c510-4f74-8943-abac78eb9802)

File Structure: An object, that has an array of presets
File Name: The preset will be exported to a file name in the syntax `<presetname>.json`